### PR TITLE
Fix: Pass db argument to get_model_context_window

### DIFF
--- a/forllm_server/llm_processing.py
+++ b/forllm_server/llm_processing.py
@@ -62,7 +62,7 @@ def process_llm_request(request_details, flask_app): # Added flask_app parameter
         logger.info(f"Request {request_id}: Attempting to fetch context window for model: {model} using ollama_utils...")
         with flask_app.app_context(): # Ensure app context for get_model_context_window
             # get_model_context_window from ollama_utils uses get_db() which relies on app context
-            model_specific_context = get_model_context_window(model)
+            model_specific_context = get_model_context_window(model, db)
 
         if model_specific_context is not None:
             effective_context_window = model_specific_context


### PR DESCRIPTION
The `get_model_context_window` function in `ollama_utils.py` requires a `db` argument, but it was being called from `llm_processing.py` without it.

This commit updates the call in `process_llm_request` within `forllm_server/llm_processing.py` to correctly pass the established database connection (`db`) to `get_model_context_window`.

This resolves the error "TypeError: get_model_context_window() missing 1 required positional argument: 'db'" that occurred during LLM request processing.