### PR TITLE
Fix: Resolve race condition in model select dropdown

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -21,9 +21,8 @@ import {
 } from './schedule.js';
 
 import {
-    loadSettings,
-    renderSettingsPage,
-    saveSettings // Although saveSettings is called internally by renderSettingsPage, keep import for clarity
+    initializeSettings,
+    renderSettingsPage
 } from './settings.js';
 
 import { loadQueueData } from './queue.js';
@@ -63,7 +62,7 @@ function initialLoad() {
         // After subforums load, show the default section (now activity page via showSection(null))
         showSection(null);
     });
-    loadSettings(); // Loads settings (which includes dark mode and model list trigger)
+    initializeSettings(); // Loads settings, models, and renders the settings UI
     loadCurrentStatus();
     loadNextSchedule();
     setInterval(loadCurrentStatus, 30000); // Update status every 30 seconds


### PR DESCRIPTION
Refactors the settings loading logic to use Promise.all, ensuring that both your settings and the list of available models are fetched before the model selection dropdown is populated. This prevents a race condition where the dropdown would incorrectly default to the first model in the list if the model list was returned before your settings.

The new `initializeSettings` function now orchestrates the fetching and rendering of all settings, improving robustness and predictability. The old `loadSettings` and `loadOllamaModels` functions have been deprecated.